### PR TITLE
Honor PSL cache options in the CLI

### DIFF
--- a/src/trustymail/cli.py
+++ b/src/trustymail/cli.py
@@ -61,7 +61,7 @@ import os
 import docopt
 
 # Local imports
-from . import trustymail
+from . import trustymail as tmail
 from ._version import __version__
 
 # The default ports to be checked to see if an SMTP server is listening.
@@ -72,14 +72,14 @@ def main():
     """Perform a trustymail scan using the provided options."""
     args = docopt.docopt(__doc__, version=__version__)
 
-    # Monkey patching trustymail to make it cache the PSL where we want
+    from . import domain
+
+    # Configure the module that reads the PSL cache.
     if args["--psl-filename"] is not None:
-        trustymail.PublicSuffixListFilename = args["--psl-filename"]
+        domain.PublicSuffixListFilename = args["--psl-filename"]
     # Monkey patching trustymail to make the PSL cache read-only
     if args["--psl-read-only"]:
-        trustymail.PublicSuffixListReadOnly = True
-    # cisagov Libraries
-    import trustymail.trustymail as tmail
+        domain.PublicSuffixListReadOnly = True
 
     log_level = logging.WARN
     if args["--debug"]:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,70 @@
+"""Tests for command-line configuration."""
+
+# Standard Python Libraries
+from collections import defaultdict
+import os
+from unittest.mock import Mock
+
+# Third-Party Libraries
+import pytest
+
+# cisagov Libraries
+from trustymail import cli, domain, trustymail
+
+
+@pytest.mark.parametrize("filename", [None, "custom.dat"])
+@pytest.mark.parametrize("read_only", [False, True])
+@pytest.mark.parametrize("cache_state", ["missing", "fresh", "stale"])
+def test_psl_options(monkeypatch, tmp_path, filename, read_only, cache_state):
+    """Honor the selected cache filename and update policy when scanning."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(domain, "PublicSuffixListFilename", "public_suffix_list.dat")
+    monkeypatch.setattr(domain, "PublicSuffixListReadOnly", False)
+    cache = tmp_path / (filename or "public_suffix_list.dat")
+    if cache_state != "missing":
+        cache.write_text("com\n", encoding="utf-8")
+        if cache_state == "stale":
+            os.utime(cache, (0, 0))
+        original_mtime = cache.stat().st_mtime_ns
+
+    # Isolate configuration from argument parsing and DNS/SMTP scanning.
+    args = defaultdict(
+        lambda: None,
+        {
+            "INPUT": ["example.com"],
+            "--psl-filename": filename,
+            "--psl-read-only": read_only,
+        },
+    )
+    monkeypatch.setattr(cli.docopt, "docopt", lambda *a, **kw: args)
+    suffixes = []
+
+    def scan(*args):
+        suffixes.append(domain.get_public_suffix("example.com"))
+
+    monkeypatch.setattr(trustymail, "scan", scan)
+    monkeypatch.setattr(trustymail, "generate_csv", Mock())
+
+    def update(filename):
+        with open(filename, "w", encoding="utf-8") as cache_file:
+            cache_file.write("com\n")
+
+    download = Mock(side_effect=update)
+    monkeypatch.setattr(domain, "updatePSL", download)
+
+    if read_only and cache_state == "missing":
+        with pytest.raises(FileNotFoundError):
+            cli.main()
+    else:
+        cli.main()
+        assert suffixes == ["example.com"]
+
+    if not read_only and cache_state != "fresh":
+        download.assert_called_once_with(str(cache.name))
+    else:
+        download.assert_not_called()
+        if cache_state != "missing":
+            assert cache.stat().st_mtime_ns == original_mtime
+            assert cache.read_text(encoding="utf-8") == "com\n"
+    if filename:
+        assert not (tmp_path / "public_suffix_list.dat").exists()


### PR DESCRIPTION
## 🗣 Description

Apply `--psl-filename` and `--psl-read-only` to the domain module that actually reads those values. The CLI currently assigns attributes on the scanner module instead, so `get_psl()` continues using its default filename and refresh policy.

## 💭 Motivation and context

Fixes #134. This keeps the existing library settings and function signatures, avoiding the API changes discussed in the closed #135. The scanner is imported before the domain module to preserve the existing circular-import initialization order.

## 🧪 Testing

- `pytest -o addopts='' -q`: 13 passed on Linux/Python 3.11.
- Twelve new combinations cover custom/default filenames, writable/read-only mode, and missing/fresh/stale caches. Eight failed before the fix; all twelve pass afterward.
- Tests use temporary local PSL files and mock the download and domain-scan boundary. No DNS or SMTP scans are performed. They check the file used, download calls, parsed suffix, preservation of read-only contents/mtime, and missing read-only cache errors.
- `pre-commit run --files src/trustymail/cli.py tests/test_cli.py`: passed, including Black, Flake8, isort, mypy, Bandit and pip-audit.

A separate existing CLI parser problem prevents a full command-line smoke test: docopt 0.6.2 raises `DocoptLanguageError: --dns is not a unique prefix: --dns, --dns?` on the unchanged CLI usage text. These tests supply parsed arguments to `main()` so they exercise PSL configuration independently of that problem. This PR does not claim to resolve that parser error.

CI follow-up: the Windows/macOS collection failures expose the pre-existing DNS package collision in #41. The separate dependency fix in #165 removes the conflicting package. A temporary combination of this PR and #165 passed all 17 tests on macOS/Python 3.11. This branch still needs that dependency fix upstream before its affected CI jobs can pass.

## ✅ Pre-approval checklist

- [x] Informative title and focused change.
- [x] Contribution instructions and prior review feedback checked.
- [x] Related issue linked.
- [x] Regression tests added; local suite and relevant pre-commit checks pass.

## ✅ Pre-merge checklist

- [ ] Maintainer review and CI completed.

