### PR TITLE
Remove conflicting py3dns dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,8 +55,7 @@ dependencies = [
     "dnspython",
     "docopt",
     "publicsuffixlist[update]",
-    "py3dns",
-    "pyspf",
+    "pyspf>=2.0.13",
     "requests",
 ]
 description = "Scan domains and return data based on trustworthy email best practices"

--- a/src/trustymail/trustymail.py
+++ b/src/trustymail/trustymail.py
@@ -12,7 +12,6 @@ import smtplib
 import socket
 
 # Third-Party Libraries
-import DNS
 import dns.resolver
 import dns.reversename
 import requests
@@ -846,17 +845,6 @@ def scan(
         DNS_RESOLVERS = dns_hostnames
     else:
         DNS_RESOLVERS = resolver.nameservers
-
-    #
-    # The spf library uses py3dns behind the scenes, so we need to configure
-    # that too
-    #
-    DNS.defaults["timeout"] = timeout
-    # Use TCP instead of UDP
-    DNS.defaults["protocol"] = "tcp"
-    # If the user passed in DNS hostnames to query against then use them
-    if dns_hostnames:
-        DNS.defaults["server"] = dns_hostnames
 
     # Domain's constructor needs all these parameters because it does a DMARC
     # scan in its init

--- a/tests/test_dns.py
+++ b/tests/test_dns.py
@@ -1,0 +1,72 @@
+"""Exercise scanning with the dnspython backend."""
+
+# Standard Python Libraries
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+# Third-Party Libraries
+import dns.resolver
+import dns.rrset
+import pytest
+
+# cisagov Libraries
+from trustymail import cli, trustymail
+
+
+def test_cli_import():
+    """Load the entry point with the installed DNS dependencies."""
+    assert callable(cli.main)
+
+
+def test_scan_dns_configuration(monkeypatch):
+    """Initialize a scan without requiring the legacy DNS backend."""
+    domain = SimpleNamespace(is_live=True)
+    monkeypatch.setattr(trustymail, "Domain", Mock(return_value=domain))
+    mx_scan = Mock()
+    monkeypatch.setattr(trustymail, "mx_scan", mx_scan)
+    monkeypatch.setattr(trustymail, "DNS_TIMEOUT", None, raising=False)
+    monkeypatch.setattr(trustymail, "DNS_RESOLVERS", None, raising=False)
+
+    result = trustymail.scan(
+        "example.com",
+        7,
+        5,
+        "localhost",
+        [25],
+        False,
+        {"mx": True, "starttls": False, "spf": False, "dmarc": False},
+        ["192.0.2.53"],
+    )
+
+    assert result is domain
+    mx_scan.assert_called_once()
+    resolver, scanned_domain = mx_scan.call_args[0]
+    assert scanned_domain is domain
+    assert resolver.nameservers == ["192.0.2.53"]
+    assert resolver.timeout == resolver.lifetime == 7
+    assert resolver.retry_servfail is False
+
+
+@pytest.mark.parametrize(
+    "included_record, valid",
+    [("v=spf1 -all", True), ("v=spf1 invalid -all", False)],
+)
+def test_spf_include_uses_dnspython(monkeypatch, included_record, valid):
+    """Validate SPF includes using real pyspf and local DNS responses."""
+
+    def query(name, record_type, **kwargs):
+        assert name == "sender.example"
+        if record_type != "TXT":
+            raise dns.resolver.NoAnswer
+        return dns.rrset.from_text(name, 60, "IN", "TXT", '"' + included_record + '"')
+
+    lookup = Mock(side_effect=query)
+    monkeypatch.setattr(dns.resolver, "query", lookup)
+    domain = SimpleNamespace(
+        domain_name="example.com", valid_spf=None, debug_info=[], syntax_errors=[]
+    )
+
+    trustymail.check_spf_record("v=spf1 include:sender.example -all", domain)
+
+    assert domain.valid_spf is valid
+    assert any(call[0] == ("sender.example", "TXT") for call in lookup.call_args_list)


### PR DESCRIPTION
## 🗣 Description

Remove the `py3dns` dependency so a fresh installation can import the scanner and CLI on case-insensitive filesystems. `py3dns` installs `DNS`, while `dnspython` installs `dns`; installing both can overwrite their package files and leave either module unimportable.

Remove the scanner's `DNS` import and legacy `DNS.defaults` configuration. Require `pyspf>=2.0.13`, which introduced support for the `dnspython` backend that current pyspf already prefers. The existing dnspython resolver configuration remains the scan's configuration path.

## 💭 Motivation and context

Fixes #41. The collision was reproduced on unchanged `develop` (`8b4b9c8`) on macOS with Python 3.11.15, dnspython 2.8.0, and py3dns 3.2.1. It also prevents the tests added in #164 from being collected in Windows and macOS CI. This PR is based directly on `develop` so the dependency fix can be reviewed separately from the PSL option change.

pyspf's backend introduction is recorded in its [2.0.13 changelog](https://github.com/sdgathman/pyspf/blob/pyspf-2.0.13/CHANGELOG). Earlier pyspf releases are excluded because they require the legacy backend. SPF evaluation continues to use pyspf. Environments whose DNS package files have already collided should be recreated with the corrected dependencies; removing a dependency alone cannot repair overwritten files.

## 🧪 Testing

- New regression module fails to collect before the source fix because the scanner imports `DNS` in an environment with only dnspython installed.
- `pytest -o addopts='' -q`: 5 passed on macOS/Python 3.11.15 with the minimum pyspf 2.0.13.
- Built the sdist and wheel with `python -m build`; installed the wheel with its dependencies into a fresh macOS/Python 3.11 environment. All 5 tests passed with pyspf 2.0.14; verified the imported CLI came from the wheel installation and py3dns was absent.
- Clean Linux/Python 3.11 Docker installation with `pip install '.[test]'`: 5 passed.
- Tests cover the CLI import, scan initialization with a custom resolver and timeout, and real pyspf evaluation of valid and invalid included SPF records. DNS responses are supplied locally; no external DNS or SMTP scans are performed.
- A temporary combination with the PSL fix in #164 passed all 17 tests on macOS/Python 3.11, including the tests previously blocked during collection.
- `pre-commit run --files pyproject.toml src/trustymail/trustymail.py tests/test_dns.py`: passed, including Black, Flake8, isort, mypy, Bandit, and pip-audit.

Windows and the broader Python matrix await CI. The existing docopt usage-text error documented in #164 remains a separate limitation; the CLI regression here covers importability.

## ✅ Pre-approval checklist

- [x] Focused dependency fix with supporting regression tests.
- [x] Contribution instructions, issue discussion, history, and competing PRs checked.
- [x] Related issue linked and compatibility requirement stated.
- [x] Local tests, package build, and applicable pre-commit checks pass.

## ✅ Pre-merge checklist

- [ ] Maintainer review and CI completed.

Prepared on behalf of @rksharma-owg with OpenAI Codex.
